### PR TITLE
fix: ignore all @strapi/* updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "@strapi/*"


### PR DESCRIPTION
Strapi cannot be updated one by one package and should be checked for migrations